### PR TITLE
Fix typo in transparency docstring

### DIFF
--- a/vcsd/util/files.py
+++ b/vcsd/util/files.py
@@ -143,7 +143,7 @@ def load_trans_pair(path_im_A="", path_im_B=""):
     """Load the image files of the pair of transparencies
 
     Load the image files (in .png format) of the pair of transparencies and extract the 2D arrays with the transparences.
-    If checks are successful return each transpacencie of the pair as a 2D numpy array.
+    If checks are successful return each transparency of the pair as a 2D numpy array.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- correct 'transpacencie' typo to 'transparency' in `load_trans_pair` docstring

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961896852483289c70018f4d7acb34