### PR TITLE
Add Sphinx docs and usage examples

### DIFF
--- a/VisioCrypt/decryptor.py
+++ b/VisioCrypt/decryptor.py
@@ -6,9 +6,16 @@ from PIL import Image
 
 import VisioCrypt.util as util
 
-# TODO docstring for CvedDecryptor class
+
 class Decryptor():
-    """
+    """Operations to recover data from a pair of transparencies.
+
+    The :class:`Decryptor` class performs the inverse operations of
+    :class:`~VisioCrypt.encryptor.Encryptor`.  Given two transparency matrices
+    it reconstructs the original QR code and extracts the encoded text.
+
+    The class does not hold any state; a single instance can process many
+    transparency pairs.
     """
 
 

--- a/VisioCrypt/encryptor.py
+++ b/VisioCrypt/encryptor.py
@@ -6,10 +6,21 @@ from PIL import Image
 
 import VisioCrypt.util as util
 
-# TODO docstring for CvedEncryptor class
+
 class Encryptor():
-    '''
-    '''
+    """High level helper to generate QR codes and visual shares.
+
+    The :class:`Encryptor` class provides the pieces needed to transform a
+    piece of text into two *transparencies* that visually encrypt the
+    information.  It currently exposes utilities to:
+
+    * Create a QR code matrix from arbitrary data.
+    * Split the QR code into two binary matrices that can later be combined
+      to recover the original code.
+
+    Instances of this class are stateless and can be reused for multiple
+    encryptions.
+    """
 
 
     def generate_qr(self, data):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,27 @@
+API Reference
+=============
+
+Encryptor
+---------
+
+.. autoclass:: VisioCrypt.encryptor.Encryptor
+   :members:
+
+Decryptor
+---------
+
+.. autoclass:: VisioCrypt.decryptor.Decryptor
+   :members:
+
+Utilities
+---------
+
+.. automodule:: VisioCrypt.util.files
+   :members:
+
+CLI
+---
+
+.. autofunction:: VisioCrypt.main.apply_encryption
+
+.. autofunction:: VisioCrypt.main.apply_decryption

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+# Add project root to sys.path for autodoc
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'VisioCrypt'
+extensions = ['sphinx.ext.autodoc']
+templates_path = ['_templates']
+exclude_patterns = []
+
+html_theme = 'alabaster'
+
+autodoc_member_order = 'bysource'

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,0 +1,12 @@
+Examples
+========
+
+Basic usage demonstrating in-memory encryption and decryption:
+
+.. literalinclude:: ../examples/basic_usage.py
+   :language: python
+
+File roundtrip demonstrating saving and loading transparency images:
+
+.. literalinclude:: ../examples/file_roundtrip.py
+   :language: python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,9 @@
+Welcome to VisioCrypt's documentation!
+======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api
+   examples

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,0 +1,15 @@
+"""Encrypt and decrypt a message in memory."""
+
+from VisioCrypt import apply_encryption, apply_decryption
+
+
+def main() -> None:
+    message = "hello world"
+    trans_a, trans_b = apply_encryption(message)
+    recovered = apply_decryption(trans_a, trans_b)
+    print(f"Original: {message}")
+    print(f"Recovered: {recovered}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/file_roundtrip.py
+++ b/examples/file_roundtrip.py
@@ -1,0 +1,24 @@
+"""Save generated transparencies and decrypt from the saved files."""
+
+from VisioCrypt import apply_encryption, apply_decryption
+
+
+def main() -> None:
+    message = "hello world"
+    apply_encryption(
+        message,
+        save_ims_gen_trans=True,
+        path_im_A="trans_A.png",
+        path_im_B="trans_B.png",
+    )
+    recovered = apply_decryption(
+        load_from_files=True,
+        path_im_A="trans_A.png",
+        path_im_B="trans_B.png",
+    )
+    print(f"Original: {message}")
+    print(f"Recovered: {recovered}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document Encryptor and Decryptor classes
- add Sphinx configuration and API docs
- provide sample encryption/decryption scripts

## Testing
- `pytest`
- `sphinx-build -b html docs docs/_build/html`


------
https://chatgpt.com/codex/tasks/task_e_68962a89005083289e8c7dd3cf6384f0